### PR TITLE
Add product & pixel relation management to Game URL form and backend; remove legacy relation views

### DIFF
--- a/SteamApp.Client/src/app/app.routes.ts
+++ b/SteamApp.Client/src/app/app.routes.ts
@@ -3,8 +3,6 @@ import {
   GameForm,
   GamesView,
   GameUrlForm,
-  GameUrlProductForm,
-  GameUrlProductsView,
   GameUrlsView,
   LoginComponent,
   ManualModeV2,
@@ -20,9 +18,7 @@ import {
   WatchListsView,
   WebScraperComponent,
   WishListForm,
-  WishListsView,
-  GameUrlPixelForm,
-  GameUrlPixelsView
+  WishListsView
 } from './pages';
 import { AuthGuard } from './services/auth/auth.guard';
 
@@ -64,15 +60,6 @@ export const routes: Routes = [
       { path: 'watch-list', component: WatchListsView, title: 'Watch List' },
       { path: 'watch-list/create', component: WatchListForm, title: 'Create Watch List Item' },
       { path: 'watch-list/edit/:id', component: WatchListForm, title: 'Edit Watch List Item' },
-
-      { path: 'game-url-products', component: GameUrlProductsView, title: 'Game URL Products' },
-      { path: 'game-url-products/create', component: GameUrlProductForm, title: 'Create Game URL Product' },
-      {
-        path: 'game-url-products/edit/:productId/:gameUrlId',
-        component: GameUrlProductForm,
-        title: 'Edit Game URL Product',
-      },
-
       { path: 'product-tags', component: ProductTagsView, title: 'Product Tags' },
       { path: 'product-tags/create', component: ProductTagForm, title: 'Create Product Tag' },
       {
@@ -84,14 +71,6 @@ export const routes: Routes = [
       { path: 'tags', component: TagsView, title: 'Tags' },
       { path: 'tags/create', component: TagForm, title: 'Create Tag' },
       { path: 'tags/edit/:id', component: TagForm, title: 'Edit Tag' },
-
-      { path: 'game-url-pixels', component: GameUrlPixelsView, title: 'Game URL Pixels' },
-      { path: 'game-url-pixels/create', component: GameUrlPixelForm, title: 'Create Game URL Pixel' },
-      {
-        path: 'game-url-pixels/edit/:pixelId/:gameUrlId',
-        component: GameUrlPixelForm,
-        title: 'Edit Game URL Pixel',
-      },
     ],
   },
 ];

--- a/SteamApp.Client/src/app/components/site-header/site-header.component.html
+++ b/SteamApp.Client/src/app/components/site-header/site-header.component.html
@@ -6,10 +6,7 @@
                         { label: 'Manual Scraper', route: '/manual-mode-v2' }]"></steam-dropdown>
                         <a routerLink="/games" routerLinkActive="active">Games</a>
 
-                        <steam-dropdown label="Game URLs" [links]="[
-                        { label: 'Game URLs', route: '/game-urls' },
-                        { label: 'Game URL Products', route: '/game-url-products' },
-                        { label: 'Game URL Pixels', route: '/game-url-pixels' }]"></steam-dropdown> 
+                        <a routerLink="/game-urls" routerLinkActive="active">Game URLs</a>
 
                                         <steam-dropdown label="Products" [links]="[{ label: 'Products', route: '/products' }, 
                                                                 { label: 'Product Tags', route: '/product-tags' }]"></steam-dropdown>

--- a/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.html
+++ b/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.html
@@ -78,11 +78,57 @@
   </div>
   }
 
+  <div class="relation-section">
+    <h3>Products for this Game URL</h3>
+    @if (filteredProducts.length === 0)
+    {
+      <p class="relation-empty">No products available for this game.</p>
+    }
+    @else {
+      <div class="relation-grid">
+        @for (product of filteredProducts; track product.id)
+        {
+          <label>
+            <input
+              type="checkbox"
+              [checked]="isProductSelected(product.id)"
+              (change)="toggleProduct(product.id, $any($event.target).checked)"
+            />
+            {{ product.name || 'Unnamed product' }}
+          </label>
+        }
+      </div>
+    }
+  </div>
+
+  <div class="relation-section">
+    <h3>Pixels for this Game URL</h3>
+    @if (filteredPixels.length === 0)
+    {
+      <p class="relation-empty">No pixels available for this game.</p>
+    }
+    @else {
+      <div class="relation-grid">
+        @for (pixel of filteredPixels; track pixel.id)
+        {
+          <label>
+            <input
+              type="checkbox"
+              [checked]="isPixelSelected(pixel.id)"
+              (change)="togglePixel(pixel.id, $any($event.target).checked)"
+            />
+            {{ pixel.name }}
+          </label>
+        }
+      </div>
+    }
+  </div>
+
   <div class="flex gap-x-2">
     <button type="submit" [disabled]="form.invalid">
       {{ isEditMode ? 'Save' : 'Create' }}
     </button>
 
-    <button type="return" (click)="cancel()">Back</button>
+    <button type="button" (click)="cancel()">Back</button>
   </div>
 </form>

--- a/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.scss
+++ b/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.scss
@@ -1,0 +1,17 @@
+.relation-section {
+  margin: 1rem 0;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+}
+
+.relation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.5rem;
+}
+
+.relation-empty {
+  color: #6b7280;
+  margin: 0;
+}

--- a/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.ts
+++ b/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.ts
@@ -2,11 +2,16 @@ import { Component, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { forkJoin, of, switchMap } from 'rxjs';
 
 import { GameUrlService } from '../../../services/game-url/game-url.service';
 import { CreateGameUrl, UpdateGameUrl } from '../../../models/game-url.model';
 import { GameService } from '../../../services/game/game.service';
-import { Game } from '../../../models';
+import { Game, PixelListItem, Product } from '../../../models';
+import { ProductService } from '../../../services/product/product.service';
+import { PixelService } from '../../../services/pixel/pixel.service';
+import { GameUrlProductService } from '../../../services/game-url-product/game-url-product.service';
+import { GameUrlPixelService } from '../../../services/game-url-pixel/game-url-pixel.service';
 
 @Component({
   selector: 'steam-game-url-form',
@@ -21,6 +26,15 @@ export class GameUrlForm implements OnInit {
   gameUrlId?: number;
 
   readonly games = signal<readonly Game[]>([]);
+  readonly products = signal<readonly Product[]>([]);
+  readonly pixels = signal<readonly PixelListItem[]>([]);
+
+  readonly selectedProductIds = signal<readonly number[]>([]);
+  readonly selectedPixelIds = signal<readonly number[]>([]);
+
+  private initialProductIds: number[] = [];
+  private initialPixelIds: number[] = [];
+
   readonly isBatchUrl = signal(false);
   readonly isPixelScrape = signal(false);
   readonly isPublicApi = signal(false);
@@ -47,6 +61,10 @@ export class GameUrlForm implements OnInit {
     private readonly router: Router,
     private readonly gameUrlService: GameUrlService,
     private readonly gameService: GameService,
+    private readonly productService: ProductService,
+    private readonly pixelService: PixelService,
+    private readonly gameUrlProductService: GameUrlProductService,
+    private readonly gameUrlPixelService: GameUrlPixelService,
   ) {}
 
   ngOnInit(): void {
@@ -84,9 +102,9 @@ export class GameUrlForm implements OnInit {
       this.syncSignalsFromForm();
     });
 
-    const idParam = this.route.snapshot.paramMap.get('id');
+    this.loadLookupData();
 
-    this.loadGames();
+    const idParam = this.route.snapshot.paramMap.get('id');
 
     if (idParam)
     {
@@ -96,6 +114,48 @@ export class GameUrlForm implements OnInit {
     }
   }
 
+  get filteredProducts(): readonly Product[]
+  {
+    const gameId = this.form.controls.gameId.value;
+    return this.products().filter(x => x.gameId === gameId);
+  }
+
+  get filteredPixels(): readonly PixelListItem[]
+  {
+    const gameId = this.form.controls.gameId.value;
+    return this.pixels().filter(x => x.gameId === gameId);
+  }
+
+  isProductSelected(productId: number): boolean
+  {
+    return this.selectedProductIds().includes(productId);
+  }
+
+  isPixelSelected(pixelId: number): boolean
+  {
+    return this.selectedPixelIds().includes(pixelId);
+  }
+
+  toggleProduct(productId: number, checked: boolean): void
+  {
+    const selected = new Set(this.selectedProductIds());
+
+    if (checked) { selected.add(productId); }
+    else { selected.delete(productId); }
+
+    this.selectedProductIds.set([...selected]);
+  }
+
+  togglePixel(pixelId: number, checked: boolean): void
+  {
+    const selected = new Set(this.selectedPixelIds());
+
+    if (checked) { selected.add(pixelId); }
+    else { selected.delete(pixelId); }
+
+    this.selectedPixelIds.set([...selected]);
+  }
+
   private syncSignalsFromForm(): void
   {
     this.isPublicApi.set(this.form.controls.isPublicApi.value === true);
@@ -103,44 +163,58 @@ export class GameUrlForm implements OnInit {
     this.isPixelScrape.set(this.form.controls.isPixelScrape.value === true);
   }
 
-  private loadGames(): void
+  private loadLookupData(): void
   {
-    this.gameService.getAll().subscribe(games =>
-    {
-      this.games.set(games);
-    });
+    this.gameService.getAll().subscribe(games => this.games.set(games));
+    this.productService.getAll().subscribe(products => this.products.set(products));
+    this.pixelService.getAll().subscribe(pixels => this.pixels.set(pixels));
   }
 
   private loadGameUrl(id: number): void
   {
-    this.gameUrlService.getById(id).subscribe(gameUrl =>
-    {
-      this.form.patchValue({
-        gameId: Number(gameUrl.gameId),
-        name: gameUrl.name ?? '',
-        partialUrl: gameUrl.partialUrl ?? '',
-        isBatchUrl: gameUrl.isBatchUrl,
-        startPage: gameUrl.startPage,
-        endPage: gameUrl.endPage,
-        isPixelScrape: gameUrl.isPixelScrape,
+    this.gameUrlService.getById(id)
+      .pipe(
+        switchMap(gameUrl =>
+        {
+          this.form.patchValue({
+            gameId: Number(gameUrl.gameId),
+            name: gameUrl.name ?? '',
+            partialUrl: gameUrl.partialUrl ?? '',
+            isBatchUrl: gameUrl.isBatchUrl,
+            startPage: gameUrl.startPage,
+            endPage: gameUrl.endPage,
+            isPixelScrape: gameUrl.isPixelScrape,
 
-        pixelX: gameUrl.pixelX,
-        pixelY: gameUrl.pixelY,
-        pixelImageWidth: gameUrl.pixelImageWidth,
-        pixelImageHeight: gameUrl.pixelImageHeight,
-        isPublicApi: gameUrl.isPublicApi,
-      });
+            pixelX: gameUrl.pixelX,
+            pixelY: gameUrl.pixelY,
+            pixelImageWidth: gameUrl.pixelImageWidth,
+            pixelImageHeight: gameUrl.pixelImageHeight,
+            isPublicApi: gameUrl.isPublicApi,
+          });
 
-      if (gameUrl.isPublicApi)
+          if (gameUrl.isPublicApi)
+          {
+            this.form.controls.isBatchUrl.disable({ emitEvent: false });
+            this.form.controls.isPixelScrape.disable({ emitEvent: false });
+          }
+
+          this.syncSignalsFromForm();
+          this.form.controls.gameId.disable();
+
+          return forkJoin({
+            products: this.gameUrlProductService.existsByGameUrl(id),
+            pixels: this.gameUrlPixelService.existsByGameUrl(id),
+          });
+        })
+      )
+      .subscribe(({ products, pixels }) =>
       {
-        this.form.controls.isBatchUrl.disable({ emitEvent: false });
-        this.form.controls.isPixelScrape.disable({ emitEvent: false });
-      }
+        this.initialProductIds = products.map(x => x.productId);
+        this.initialPixelIds = pixels.map(x => x.pixelId);
 
-      this.syncSignalsFromForm();
-
-      this.form.controls.gameId.disable();
-    });
+        this.selectedProductIds.set([...this.initialProductIds]);
+        this.selectedPixelIds.set([...this.initialPixelIds]);
+      });
   }
 
   onSubmit(): void
@@ -154,20 +228,55 @@ export class GameUrlForm implements OnInit {
     {
       const update: UpdateGameUrl = this.form.getRawValue();
 
-      this.gameUrlService.update(this.gameUrlId, update).subscribe(() =>
-      {
-        this.router.navigate(['/game-urls']);
-      });
+      this.gameUrlService.update(this.gameUrlId, update)
+        .pipe(switchMap(() => this.syncRelations(this.gameUrlId!)))
+        .subscribe(() =>
+        {
+          this.router.navigate(['/game-urls']);
+        });
     }
     else
     {
       const create: CreateGameUrl = this.form.getRawValue();
 
-      this.gameUrlService.create(create).subscribe(() =>
-      {
-        this.router.navigate(['/game-urls']);
-      });
+      this.gameUrlService.create(create)
+        .pipe(switchMap(created => this.syncRelations(created.id)))
+        .subscribe(() =>
+        {
+          this.router.navigate(['/game-urls']);
+        });
     }
+  }
+
+  private syncRelations(gameUrlId: number)
+  {
+    const selectedProducts = this.selectedProductIds();
+    const selectedPixels = this.selectedPixelIds();
+
+    const productAdds = selectedProducts
+      .filter(x => !this.initialProductIds.includes(x))
+      .map(productId => this.gameUrlProductService.create({ productId, gameUrlId }));
+
+    const productDeletes = this.initialProductIds
+      .filter(x => !selectedProducts.includes(x))
+      .map(productId => this.gameUrlProductService.delete(productId, gameUrlId));
+
+    const pixelAdds = selectedPixels
+      .filter(x => !this.initialPixelIds.includes(x))
+      .map(pixelId => this.gameUrlPixelService.create({ pixelId, gameUrlId }));
+
+    const pixelDeletes = this.initialPixelIds
+      .filter(x => !selectedPixels.includes(x))
+      .map(pixelId => this.gameUrlPixelService.delete(pixelId, gameUrlId));
+
+    const requests = [...productAdds, ...productDeletes, ...pixelAdds, ...pixelDeletes];
+
+    if (requests.length === 0)
+    {
+      return of(void 0);
+    }
+
+    return forkJoin(requests).pipe(switchMap(() => of(void 0)));
   }
 
   cancel(): void

--- a/SteamApp.Client/src/app/services/game-url-pixel/game-url-pixel.service.ts
+++ b/SteamApp.Client/src/app/services/game-url-pixel/game-url-pixel.service.ts
@@ -30,6 +30,14 @@ export class GameUrlPixelService {
       .pipe(catchError(handleError));
   }
 
+
+  // GET: /api/game-url-pixels/{gameUrlId}
+  existsByGameUrl(gameUrlId: number): Observable<GameUrlPixel[]> {
+    return this.http
+      .get<GameUrlPixel[]>(`${this.baseUrl}/${gameUrlId}`)
+      .pipe(catchError(handleError));
+  }
+
   // POST: /api/game-url-pixels
   create(input: CreateGameUrlPixel): Observable<void> {
     return this.http

--- a/SteamApp.Server/SteamApp.WebAPI/MinimalAPIs/GameUrlPixelsEndpoints.cs
+++ b/SteamApp.Server/SteamApp.WebAPI/MinimalAPIs/GameUrlPixelsEndpoints.cs
@@ -55,6 +55,34 @@ public static class GameUrlPixelsEndpoints
                 : Results.NotFound();
         });
 
+        // GET: /api/game-url-pixels/{gameUrlId}
+        group.MapGet("/{gameUrlId:long}", async (
+            long gameUrlId,
+            ApplicationDbContext db) =>
+        {
+            var relations = await db.GameUrlsPixels
+                .AsNoTracking()
+                .Where(x => x.GameUrlId == gameUrlId)
+                .Select(x => new
+                {
+                    x.PixelId,
+                    PixelName = x.Pixel.Name,
+                    x.GameUrlId,
+                    GameUrlName = x.GameUrl.Name,
+                    GameName = x.GameUrl.Game.Name,
+                    GameUrlPixelLocationX = x.GameUrl.PixelX,
+                    GameUrlPixelLocationY = x.GameUrl.PixelY,
+                    GameUrlImageWidth = x.GameUrl.PixelImageWidth,
+                    GameUrlImageHeight = x.GameUrl.PixelImageHeight,
+                    x.Pixel.RedValue,
+                    x.Pixel.BlueValue,
+                    x.Pixel.GreenValue
+                })
+                .ToListAsync();
+
+            return Results.Ok(relations);
+        });
+
         // POST: /api/game-url-pixels
         group.MapPost("/", async (
             GameUrlPixelCreateDto input,


### PR DESCRIPTION
### Motivation

- Provide a way to manage product and pixel relations directly from the Game URL form instead of separate legacy views.
- Expose an API to query existing pixel relations by `gameUrlId` to support client-side relation sync.
- Simplify navigation by removing deprecated Game URL Products/Pixels pages and header dropdown entries.

### Description

- Added product and pixel selection UI to the `GameUrlForm` with checkbox lists, responsive styling, and a fixed `Back` button type (`type="button"`).
- Introduced signals and selection state in `game-url-form.ts`, lookup loading (`loadLookupData`) for games/products/pixels, filtered views (`filteredProducts`, `filteredPixels`), toggle helpers (`toggleProduct`, `togglePixel`), and initial selection tracking to compute changes.
- Implemented relation synchronization in `GameUrlForm` (`syncRelations`) that creates/deletes `game-url-product` and `game-url-pixel` relations using `GameUrlProductService` and `GameUrlPixelService`, leveraging `forkJoin`/`of` and `switchMap` to chain requests on create/update flows.
- Added `existsByGameUrl` to the `GameUrlPixelService` client to fetch relations by `gameUrlId`, and added a new server endpoint `GET /api/game-url-pixels/{gameUrlId}` to return pixel relations for a given Game URL.
- Removed routes and header entries for the legacy `game-url-products` and `game-url-pixels` views from `app.routes.ts` and `site-header.component.html` respectively.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44b85b02c832fb0bdf3efd5c5308e)