### PR TITLE
Add relation management UIs, Excel export, API endpoint and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,193 +1,100 @@
-# Web Scraping CRM for Steam Community market
+# Steam Web Scraping CRM
 
-**An Angular 21 client integrated with a .NET 9 Web API backend**. This application helps you find items listed on the Steam Community Market at favorable price ranges—whether you’re investing or simply adding to your personal collection.
+A full-stack application for tracking and analyzing Steam Community Market listings.
 
-> **Disclaimer**: This project is **not** affiliated with, endorsed, or sponsored by Valve Software. It simply consumes publicly available endpoints provided by Valve.
+- **Frontend:** Angular 21 (`SteamApp.Client`)
+- **Backend:** .NET 9 Web API (`SteamApp.Server/SteamApp.WebAPI`)
+- **Primary use case:** maintain game/product/tag/pixel metadata and run market scraping workflows with watch/wish list automation.
 
----
+> **Disclaimer**
+> This project is not affiliated with, endorsed by, or sponsored by Valve Software.
 
-## 🚀 Features
-- 💰 **Price Scanning**: Quickly search for listings on the Steam Community Market within your desired price range.
-- 🏷️ **Minimalistic UI**: A sleek interface built with Angular, Tailwind, and SCSS for a focused user experience.
-- ⏱️ **Real-Time Updates**: Fetch live listing and pricing data directly from the Steam Community Market.
-- 📈 **Investment Insights**: Identify undervalued items that might be profitable for collectors or traders.
+## Documentation index
 
-## Backend
+- [Getting Started](docs/GETTING_STARTED.md)
+- [Architecture Overview](docs/ARCHITECTURE.md)
+- [API Reference](docs/API_REFERENCE.md)
+- [Contributing Guide](docs/CONTRIBUTING.md)
 
-- **In-memory caching** (IMemoryCache)
-- **JWT authentication**
-- **.NET Minimal APIs**
-- **Email integration** (Mailtrap)
-- **Background jobs**
-- **AutoMapper**
-- **Logging**
-- **User Secrets**
+## Quick start
 
-## Frontend
+### 1) Clone
 
-- **Angular**
-- **Tailwind CSS + SCSS**
-- **Auth guard** (route protection)
-- **HTTP interceptor**
-- **RxJS**
-- **Angular Material tables**
-- **Environment variables**
+```bash
+git clone <your-repository-url>
+cd Steam-Web-Scraping-CRM
+```
 
----
+### 2) Start backend
 
-## 📥 Installation
+```bash
+cd SteamApp.Server/SteamApp.WebAPI
+# configure secrets/env vars first (see docs/GETTING_STARTED.md)
+dotnet restore
+dotnet build
+dotnet run
+```
 
-1. **Clone the Repository**:
-   ```bash
-   git clone *repo*
-   ```
-2. **Install Angular Client Dependencies**:
-    ```bash
-    npm install
-    ```
-3. **Restore & Build the .NET 9 Web API**:
-    ```bash
-    dotnet restore
-    dotnet build
-    ```
-4. **Setup User Secrets + Database**:
-    - Request User Secrets from the owener of the repo
-   ```bash
-   update-database
-   ```
-5. **Run the Application**:
-Terminal 1 (Web API):
-   ```bash
-   dotnet run
-   ```
-6. **Terminal 2 (Angular client)**:
-   ```bash
-    npm start
-   ```
-Open your browser at http://localhost:4200.
+### 3) Start frontend
 
-## 📌 Requirements
-- 🏷️ Node.js (latest LTS recommended)
-- 🎯 .NET 9 SDK
-- Mailtrap setup guide https://github.com/mailtrap/mailtrap-dotnet
+```bash
+cd SteamApp.Client
+npm install
+npm start
+```
 
+- Frontend: `http://localhost:4200`
+- Backend swagger: `https://localhost:7273/swagger` (port may vary by local profile)
 
-# SteamApp API — Endpoints
+## Core features
 
-Auth: Bearer JWT (global)
+- CRUD for Games, Game URLs, Products, Pixels, Tags, Wish List, Watch List.
+- M2M relation management from primary forms:
+  - Game URL ↔ Products
+  - Game URL ↔ Pixels
+  - Product ↔ Tags
+- Data-table filters and export to Excel in key pages.
+- JWT auth and protected API routes.
+- Background worker support for wishlist checks.
 
-## Auth
+## Tech stack
 
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| POST | `/api/Auth/token` | `TokenRequest` | Returns `200 OK` |
+### Frontend
 
-## Games
+- Angular 21
+- Angular Material
+- RxJS
+- Tailwind + SCSS
+- XLSX export
 
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/games` | — | `GetAllGames` → `200 OK` (`GameDto[]`) |
-| POST | `/api/games` | `GameCreateDto` | `CreateGame` → `201 Created` (`GameDto`) |
-| GET | `/api/games/{id}` | — | `GetGameById` → `200 OK` (`GameDto`), `404 Not Found` |
-| PUT | `/api/games/{id}` | `GameUpdateDto` | `UpdateGame` → `204 No Content`, `404 Not Found` |
-| DELETE | `/api/games/{id}` | — | `DeleteGame` → `204 No Content`, `404 Not Found` |
+### Backend
 
-## GameUrlPixels
+- ASP.NET Core (.NET 9)
+- Minimal APIs + Controllers
+- Entity Framework Core (SQL Server)
+- JWT auth
+- AutoMapper
+- Hosted background worker(s)
 
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/game-url-pixels` | — | `200 OK` |
-| POST | `/api/game-url-pixels` | `GameUrlPixelCreateDto` | `200 OK` |
-| GET | `/api/game-url-pixels/{pixelId}/{gameUrlId}` | — | `pixelId:int64`, `gameUrlId:int64` → `200 OK` |
-| DELETE | `/api/game-url-pixels/{pixelId}/{gameUrlId}` | — | `pixelId:int64`, `gameUrlId:int64` → `200 OK` |
+## Current repository layout
 
-## GameUrlProducts
+```text
+Steam-Web-Scraping-CRM/
+├─ SteamApp.Client/                  # Angular application
+├─ SteamApp.Server/
+│  ├─ SteamApp.WebAPI/              # ASP.NET Core API host
+│  ├─ SteamApp.Application/         # DTOs / application layer
+│  ├─ SteamApp.Infrastructure/      # infra services/repos
+│  ├─ SteamApp.Models/              # domain layer
+│  └─ SteamApp.Tests/               # tests
+└─ docs/                            # project documentation
+```
 
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/game-url-products` | — | `200 OK` |
-| POST | `/api/game-url-products` | `GameUrlProductCreateDto` | `200 OK` |
-| GET | `/api/game-url-products/{productId}/{gameUrlId}` | — | `productId:int64`, `gameUrlId:int64` → `200 OK` |
-| DELETE | `/api/game-url-products/{productId}/{gameUrlId}` | — | `productId:int64`, `gameUrlId:int64` → `200 OK` |
-| GET | `/api/game-url-products/{gameUrlId}` | — | `gameUrlId:int64` → `200 OK` |
+## Support
 
-## GameUrls
+If you want help running the stack locally, open an issue with:
 
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/game-urls` | — | `GetAllGameUrls` → `200 OK` |
-| POST | `/api/game-urls` | `GameUrlCreateDto` | `CreateGameUrl` → `201 Created` (`GameUrlDto`), `400 Bad Request` |
-| GET | `/api/game-urls/{id}` | — | `id:int64` → `GetGameUrlById` (`200 OK` / `404 Not Found`) |
-| PUT | `/api/game-urls/{id}` | `GameUrlUpdateDto` | `id:int64` → `UpdateGameUrl` (`204 No Content` / `404 Not Found`) |
-| DELETE | `/api/game-urls/{id}` | — | `id:int64` → `DeleteGameUrl` (`204 No Content` / `404 Not Found`) |
-
-## Pixels
-
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/pixels` | — | `GetAllPixels` → `200 OK` |
-| POST | `/api/pixels` | `PixelCreateDto` | `CreatePixel` → `201 Created` (`PixelDto`), `400 Bad Request` |
-| GET | `/api/pixels/{id}` | — | `id:int64` → `GetPixelById` (`200 OK` / `404 Not Found`) |
-| PUT | `/api/pixels/{id}` | `PixelUpdateDto` | `id:int64` → `UpdatePixel` (`204 No Content` / `404 Not Found`) |
-| DELETE | `/api/pixels/{id}` | — | `id:int64` → `DeletePixel` (`204 No Content` / `404 Not Found`) |
-
-## Products
-
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/products` | — | `GetAllProducts` → `200 OK` |
-| POST | `/api/products` | `ProductCreateDto` | `CreateProduct` → `201 Created` (`ProductDto`), `400 Bad Request` |
-| GET | `/api/products/{id}` | — | `id:int64` → `GetProductById` (`200 OK` / `404 Not Found`) |
-| PUT | `/api/products/{id}` | `ProductUpdateDto` | `id:int64` → `UpdateProduct` (`204 No Content` / `404 Not Found`) |
-| DELETE | `/api/products/{id}` | — | `id:int64` → `DeleteProduct` (`204 No Content` / `404 Not Found`) |
-
-## ProductTags
-
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/product-tags` | — | `200 OK` |
-| POST | `/api/product-tags` | `ProductTagCreateDto` | `200 OK` |
-| GET | `/api/product-tags/{productId}/{tagId}` | — | `productId:int64`, `tagId:int64` → `200 OK` |
-| DELETE | `/api/product-tags/{productId}/{tagId}` | — | `productId:int64`, `tagId:int64` → `200 OK` |
-| GET | `/api/product-tags/product/{productId}` | — | `productId:int64` → `200 OK` |
-
-## Steam
-
-| Method | Path | Params | Notes |
-|---|---|---|---|
-| GET | `/steam/scrape-page/gameUrl/{gamerUrlId}/page/{page}` | `gamerUrlId:int64`, `page:int32` | `200 OK` |
-| GET | `/steam/scrape-public-api/gameUrl/{gameUrlId}/page/{page}` | `gameUrlId:int64`, `page:int32` | `200 OK` |
-| GET | `/steam/pixel-info/gameUrl/{gameUrlId}` | `gameUrlId:int64`, query `srcUrl:string?` | `200 OK` |
-| GET | `/steam/scrape-pixels/gameUrl/{gamerUrlId}/page/{page}` | path `gamerUrlId:string`, path `page:int32`, query `gameUrlId:int64?` | `200 OK` |
-| GET | `/steam/check-wishlist/{wishlistId}` | `wishlistId:int64` | `200 OK` |
-
-## Tags
-
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/tags` | — | `200 OK` |
-| POST | `/api/tags` | `TagCreateDto` | `200 OK` |
-| GET | `/api/tags/{id}` | — | `id:int64` → `200 OK` |
-| PUT | `/api/tags/{id}` | `TagUpdateDto` | `id:int64` → `200 OK` |
-| DELETE | `/api/tags/{id}` | — | `id:int64` → `200 OK` |
-| GET | `/api/tags/game/{gameId}` | — | `gameId:int64` → `200 OK` |
-
-## WatchList
-
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/watch-list` | — | `GetAllWatchList` → `200 OK` |
-| POST | `/api/watch-list` | `WatchListCreateDto` | `CreateWatchListItem` → `201 Created` (`WatchListDto`), `400 Bad Request` |
-| GET | `/api/watch-list/{id}` | — | `id:int64` → `GetWatchListItemById` (`200 OK` / `404 Not Found`) |
-| PUT | `/api/watch-list/{id}` | `WatchListUpdateDto` | `id:int64` → `UpdateWatchListItem` (`204 No Content` / `404 Not Found`) |
-| DELETE | `/api/watch-list/{id}` | — | `id:int64` → `DeleteWatchList` (`204 No Content` / `404 Not Found`) |
-
-## WishList
-
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| GET | `/api/wish-list` | — | `GetAllWishList` → `200 OK` (`WishListDto[]`) |
-| POST | `/api/wish-list` | `WishListCreateDto` | `CreateWishListItem` → `201 Created` (`WishListDto`), `400 Bad Request` |
-| GET | `/api/wish-list/{id}` | — | `id:int64` → `GetWishListById` (`200 OK` / `404 Not Found`) |
-| PUT | `/api/wish-list/{id}` | `WishListUpdateDto` | `id:int64` → `UpdateWishListItem` (`204 No Content` / `404 Not Found`) |
-| DELETE | `/api/wish-list/{id}` | — | `id:int64` → `DeleteWishList` (`204 No Content` / `404 Not Found`) |
+- OS + runtime versions (`node -v`, `dotnet --version`)
+- backend logs
+- frontend console/build output
+- the exact endpoint or page you are testing

--- a/SteamApp.Client/src/app/app.routes.ts
+++ b/SteamApp.Client/src/app/app.routes.ts
@@ -3,8 +3,6 @@ import {
   GameForm,
   GamesView,
   GameUrlForm,
-  GameUrlProductForm,
-  GameUrlProductsView,
   GameUrlsView,
   LoginComponent,
   ManualModeV2,
@@ -12,17 +10,13 @@ import {
   PixelsView,
   ProductForm,
   ProductsView,
-  ProductTagForm,
-  ProductTagsView,
   TagForm,
   TagsView,
   WatchListForm,
   WatchListsView,
   WebScraperComponent,
   WishListForm,
-  WishListsView,
-  GameUrlPixelForm,
-  GameUrlPixelsView
+  WishListsView
 } from './pages';
 import { AuthGuard } from './services/auth/auth.guard';
 
@@ -64,34 +58,9 @@ export const routes: Routes = [
       { path: 'watch-list', component: WatchListsView, title: 'Watch List' },
       { path: 'watch-list/create', component: WatchListForm, title: 'Create Watch List Item' },
       { path: 'watch-list/edit/:id', component: WatchListForm, title: 'Edit Watch List Item' },
-
-      { path: 'game-url-products', component: GameUrlProductsView, title: 'Game URL Products' },
-      { path: 'game-url-products/create', component: GameUrlProductForm, title: 'Create Game URL Product' },
-      {
-        path: 'game-url-products/edit/:productId/:gameUrlId',
-        component: GameUrlProductForm,
-        title: 'Edit Game URL Product',
-      },
-
-      { path: 'product-tags', component: ProductTagsView, title: 'Product Tags' },
-      { path: 'product-tags/create', component: ProductTagForm, title: 'Create Product Tag' },
-      {
-        path: 'product-tags/edit/:productId/:tagId',
-        component: ProductTagForm,
-        title: 'Edit Product Tag',
-      },
-
       { path: 'tags', component: TagsView, title: 'Tags' },
       { path: 'tags/create', component: TagForm, title: 'Create Tag' },
       { path: 'tags/edit/:id', component: TagForm, title: 'Edit Tag' },
-
-      { path: 'game-url-pixels', component: GameUrlPixelsView, title: 'Game URL Pixels' },
-      { path: 'game-url-pixels/create', component: GameUrlPixelForm, title: 'Create Game URL Pixel' },
-      {
-        path: 'game-url-pixels/edit/:pixelId/:gameUrlId',
-        component: GameUrlPixelForm,
-        title: 'Edit Game URL Pixel',
-      },
     ],
   },
 ];

--- a/SteamApp.Client/src/app/components/site-header/site-header.component.html
+++ b/SteamApp.Client/src/app/components/site-header/site-header.component.html
@@ -6,13 +6,9 @@
                         { label: 'Manual Scraper', route: '/manual-mode-v2' }]"></steam-dropdown>
                         <a routerLink="/games" routerLinkActive="active">Games</a>
 
-                        <steam-dropdown label="Game URLs" [links]="[
-                        { label: 'Game URLs', route: '/game-urls' },
-                        { label: 'Game URL Products', route: '/game-url-products' },
-                        { label: 'Game URL Pixels', route: '/game-url-pixels' }]"></steam-dropdown> 
+                        <a routerLink="/game-urls" routerLinkActive="active">Game URLs</a>
 
-                                        <steam-dropdown label="Products" [links]="[{ label: 'Products', route: '/products' }, 
-                                                                { label: 'Product Tags', route: '/product-tags' }]"></steam-dropdown>
+                        <a routerLink="/products" routerLinkActive="active">Products</a>
 <a routerLink="/tags" routerLinkActive="active">Tags</a>
                 <a routerLink="/pixels" routerLinkActive="active">Pixels</a>
                 <a routerLink="/wishlist" routerLinkActive="active">Game Wish List</a>

--- a/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.html
+++ b/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.html
@@ -39,11 +39,9 @@
       <input type="checkbox" formControlName="isPublicApi" />
       Public API
     </label>
-
   </div>
 
   @if (isBatchUrl()) {
-
   <div class="form-group">
     <label>Start Page</label>
     <input type="number" formControlName="startPage" class="px-2 py-1" />
@@ -56,7 +54,6 @@
   }
 
   @if (isPixelScrape()) {
-
   <div class="form-group">
     <label>Pixel X</label>
     <input type="number" formControlName="pixelX" class="px-2 py-1" />
@@ -78,11 +75,77 @@
   </div>
   }
 
+  <div class="relation-section">
+    <h3>Products for this Game URL</h3>
+    @if (filteredProducts.length === 0)
+    {
+      <p class="relation-empty">No products available for this game.</p>
+    }
+    @else {
+      <label class="relation-select-all">
+        <input
+          type="checkbox"
+          [checked]="areAllFilteredProductsSelected"
+          [indeterminate]="areSomeFilteredProductsSelected"
+          (change)="toggleAllProducts($any($event.target).checked)"
+        />
+        Select all products
+      </label>
+
+      <div class="relation-grid">
+        @for (product of filteredProducts; track product.id)
+        {
+          <label>
+            <input
+              type="checkbox"
+              [checked]="isProductSelected(product.id)"
+              (change)="toggleProduct(product.id, $any($event.target).checked)"
+            />
+            {{ product.name || 'Unnamed product' }}
+          </label>
+        }
+      </div>
+    }
+  </div>
+
+  <div class="relation-section">
+    <h3>Pixels for this Game URL</h3>
+    @if (filteredPixels.length === 0)
+    {
+      <p class="relation-empty">No pixels available for this game.</p>
+    }
+    @else {
+      <label class="relation-select-all">
+        <input
+          type="checkbox"
+          [checked]="areAllFilteredPixelsSelected"
+          [indeterminate]="areSomeFilteredPixelsSelected"
+          (change)="toggleAllPixels($any($event.target).checked)"
+        />
+        Select all pixels
+      </label>
+
+      <div class="relation-grid">
+        @for (pixel of filteredPixels; track pixel.id)
+        {
+          <label>
+            <input
+              type="checkbox"
+              [checked]="isPixelSelected(pixel.id)"
+              (change)="togglePixel(pixel.id, $any($event.target).checked)"
+            />
+            {{ pixel.name }}
+          </label>
+        }
+      </div>
+    }
+  </div>
+
   <div class="flex gap-x-2">
     <button type="submit" [disabled]="form.invalid">
       {{ isEditMode ? 'Save' : 'Create' }}
     </button>
 
-    <button type="return" (click)="cancel()">Back</button>
+    <button type="button" (click)="cancel()">Back</button>
   </div>
 </form>

--- a/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.scss
+++ b/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.scss
@@ -1,0 +1,25 @@
+.relation-section {
+  margin: 1rem 0;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+}
+
+.relation-select-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+
+.relation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.5rem;
+}
+
+.relation-empty {
+  color: #6b7280;
+  margin: 0;
+}

--- a/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.ts
+++ b/SteamApp.Client/src/app/pages/game-url/game-url-form/game-url-form.ts
@@ -2,11 +2,16 @@ import { Component, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { forkJoin, of, switchMap } from 'rxjs';
 
 import { GameUrlService } from '../../../services/game-url/game-url.service';
 import { CreateGameUrl, UpdateGameUrl } from '../../../models/game-url.model';
 import { GameService } from '../../../services/game/game.service';
-import { Game } from '../../../models';
+import { Game, PixelListItem, Product } from '../../../models';
+import { ProductService } from '../../../services/product/product.service';
+import { PixelService } from '../../../services/pixel/pixel.service';
+import { GameUrlProductService } from '../../../services/game-url-product/game-url-product.service';
+import { GameUrlPixelService } from '../../../services/game-url-pixel/game-url-pixel.service';
 
 @Component({
   selector: 'steam-game-url-form',
@@ -16,11 +21,19 @@ import { Game } from '../../../models';
   styleUrl: './game-url-form.scss',
 })
 export class GameUrlForm implements OnInit {
-
   isEditMode = false;
   gameUrlId?: number;
 
   readonly games = signal<readonly Game[]>([]);
+  readonly products = signal<readonly Product[]>([]);
+  readonly pixels = signal<readonly PixelListItem[]>([]);
+
+  readonly selectedProductIds = signal<readonly number[]>([]);
+  readonly selectedPixelIds = signal<readonly number[]>([]);
+
+  private initialProductIds: number[] = [];
+  private initialPixelIds: number[] = [];
+
   readonly isBatchUrl = signal(false);
   readonly isPixelScrape = signal(false);
   readonly isPublicApi = signal(false);
@@ -47,26 +60,25 @@ export class GameUrlForm implements OnInit {
     private readonly router: Router,
     private readonly gameUrlService: GameUrlService,
     private readonly gameService: GameService,
+    private readonly productService: ProductService,
+    private readonly pixelService: PixelService,
+    private readonly gameUrlProductService: GameUrlProductService,
+    private readonly gameUrlPixelService: GameUrlPixelService,
   ) {}
 
   ngOnInit(): void {
-
     this.syncSignalsFromForm();
 
-    this.form.controls.isPublicApi.valueChanges.subscribe(v =>
-    {
+    this.form.controls.isPublicApi.valueChanges.subscribe(v => {
       const enabled = v === true;
 
-      if (enabled)
-      {
+      if (enabled) {
         this.form.controls.isBatchUrl.setValue(false, { emitEvent: false });
         this.form.controls.isPixelScrape.setValue(false, { emitEvent: false });
 
         this.form.controls.isBatchUrl.disable({ emitEvent: false });
         this.form.controls.isPixelScrape.disable({ emitEvent: false });
-      }
-      else
-      {
+      } else {
         this.form.controls.isBatchUrl.enable({ emitEvent: false });
         this.form.controls.isPixelScrape.enable({ emitEvent: false });
       }
@@ -74,104 +86,263 @@ export class GameUrlForm implements OnInit {
       this.syncSignalsFromForm();
     });
 
-    this.form.controls.isBatchUrl.valueChanges.subscribe(() =>
-    {
+    this.form.controls.isBatchUrl.valueChanges.subscribe(() => {
       this.syncSignalsFromForm();
     });
 
-    this.form.controls.isPixelScrape.valueChanges.subscribe(() =>
-    {
+    this.form.controls.isPixelScrape.valueChanges.subscribe(() => {
       this.syncSignalsFromForm();
     });
+
+    this.form.controls.gameId.valueChanges.subscribe(() => {
+      this.pruneSelectedRelations();
+    });
+
+    this.loadLookupData();
 
     const idParam = this.route.snapshot.paramMap.get('id');
 
-    this.loadGames();
-
-    if (idParam)
-    {
+    if (idParam) {
       this.isEditMode = true;
       this.gameUrlId = Number(idParam);
       this.loadGameUrl(this.gameUrlId);
     }
   }
 
-  private syncSignalsFromForm(): void
-  {
+  get filteredProducts(): readonly Product[] {
+    const gameId = this.form.controls.gameId.value;
+    return this.products().filter(x => x.gameId === gameId);
+  }
+
+  get filteredPixels(): readonly PixelListItem[] {
+    const gameId = this.form.controls.gameId.value;
+    return this.pixels().filter(x => x.gameId === gameId);
+  }
+
+  get areAllFilteredProductsSelected(): boolean {
+    const filtered = this.filteredProducts;
+    if (filtered.length === 0) {
+      return false;
+    }
+
+    const selected = new Set(this.selectedProductIds());
+    return filtered.every(x => selected.has(x.id));
+  }
+
+  get areSomeFilteredProductsSelected(): boolean {
+    const filtered = this.filteredProducts;
+    if (filtered.length === 0) {
+      return false;
+    }
+
+    const selected = new Set(this.selectedProductIds());
+    const selectedCount = filtered.filter(x => selected.has(x.id)).length;
+
+    return selectedCount > 0 && selectedCount < filtered.length;
+  }
+
+  get areAllFilteredPixelsSelected(): boolean {
+    const filtered = this.filteredPixels;
+    if (filtered.length === 0) {
+      return false;
+    }
+
+    const selected = new Set(this.selectedPixelIds());
+    return filtered.every(x => selected.has(x.id));
+  }
+
+  get areSomeFilteredPixelsSelected(): boolean {
+    const filtered = this.filteredPixels;
+    if (filtered.length === 0) {
+      return false;
+    }
+
+    const selected = new Set(this.selectedPixelIds());
+    const selectedCount = filtered.filter(x => selected.has(x.id)).length;
+
+    return selectedCount > 0 && selectedCount < filtered.length;
+  }
+
+  isProductSelected(productId: number): boolean {
+    return this.selectedProductIds().includes(productId);
+  }
+
+  isPixelSelected(pixelId: number): boolean {
+    return this.selectedPixelIds().includes(pixelId);
+  }
+
+  toggleAllProducts(checked: boolean): void {
+    const selected = new Set(this.selectedProductIds());
+
+    for (const product of this.filteredProducts) {
+      if (checked) {
+        selected.add(product.id);
+      } else {
+        selected.delete(product.id);
+      }
+    }
+
+    this.selectedProductIds.set([...selected]);
+  }
+
+  toggleAllPixels(checked: boolean): void {
+    const selected = new Set(this.selectedPixelIds());
+
+    for (const pixel of this.filteredPixels) {
+      if (checked) {
+        selected.add(pixel.id);
+      } else {
+        selected.delete(pixel.id);
+      }
+    }
+
+    this.selectedPixelIds.set([...selected]);
+  }
+
+  toggleProduct(productId: number, checked: boolean): void {
+    const selected = new Set(this.selectedProductIds());
+
+    if (checked) {
+      selected.add(productId);
+    } else {
+      selected.delete(productId);
+    }
+
+    this.selectedProductIds.set([...selected]);
+  }
+
+  togglePixel(pixelId: number, checked: boolean): void {
+    const selected = new Set(this.selectedPixelIds());
+
+    if (checked) {
+      selected.add(pixelId);
+    } else {
+      selected.delete(pixelId);
+    }
+
+    this.selectedPixelIds.set([...selected]);
+  }
+
+  private pruneSelectedRelations(): void {
+    const allowedProductIds = new Set(this.filteredProducts.map(x => x.id));
+    const allowedPixelIds = new Set(this.filteredPixels.map(x => x.id));
+
+    this.selectedProductIds.set(this.selectedProductIds().filter(x => allowedProductIds.has(x)));
+    this.selectedPixelIds.set(this.selectedPixelIds().filter(x => allowedPixelIds.has(x)));
+  }
+
+  private syncSignalsFromForm(): void {
     this.isPublicApi.set(this.form.controls.isPublicApi.value === true);
     this.isBatchUrl.set(this.form.controls.isBatchUrl.value === true);
     this.isPixelScrape.set(this.form.controls.isPixelScrape.value === true);
   }
 
-  private loadGames(): void
-  {
-    this.gameService.getAll().subscribe(games =>
-    {
-      this.games.set(games);
-    });
+  private loadLookupData(): void {
+    this.gameService.getAll().subscribe(games => this.games.set(games));
+    this.productService.getAll().subscribe(products => this.products.set(products));
+    this.pixelService.getAll().subscribe(pixels => this.pixels.set(pixels));
   }
 
-  private loadGameUrl(id: number): void
-  {
-    this.gameUrlService.getById(id).subscribe(gameUrl =>
-    {
-      this.form.patchValue({
-        gameId: Number(gameUrl.gameId),
-        name: gameUrl.name ?? '',
-        partialUrl: gameUrl.partialUrl ?? '',
-        isBatchUrl: gameUrl.isBatchUrl,
-        startPage: gameUrl.startPage,
-        endPage: gameUrl.endPage,
-        isPixelScrape: gameUrl.isPixelScrape,
+  private loadGameUrl(id: number): void {
+    this.gameUrlService
+      .getById(id)
+      .pipe(
+        switchMap(gameUrl => {
+          this.form.patchValue({
+            gameId: Number(gameUrl.gameId),
+            name: gameUrl.name ?? '',
+            partialUrl: gameUrl.partialUrl ?? '',
+            isBatchUrl: gameUrl.isBatchUrl,
+            startPage: gameUrl.startPage,
+            endPage: gameUrl.endPage,
+            isPixelScrape: gameUrl.isPixelScrape,
 
-        pixelX: gameUrl.pixelX,
-        pixelY: gameUrl.pixelY,
-        pixelImageWidth: gameUrl.pixelImageWidth,
-        pixelImageHeight: gameUrl.pixelImageHeight,
-        isPublicApi: gameUrl.isPublicApi,
+            pixelX: gameUrl.pixelX,
+            pixelY: gameUrl.pixelY,
+            pixelImageWidth: gameUrl.pixelImageWidth,
+            pixelImageHeight: gameUrl.pixelImageHeight,
+            isPublicApi: gameUrl.isPublicApi,
+          });
+
+          if (gameUrl.isPublicApi) {
+            this.form.controls.isBatchUrl.disable({ emitEvent: false });
+            this.form.controls.isPixelScrape.disable({ emitEvent: false });
+          }
+
+          this.syncSignalsFromForm();
+          this.form.controls.gameId.disable();
+
+          return forkJoin({
+            products: this.gameUrlProductService.existsByGameUrl(id),
+            pixels: this.gameUrlPixelService.existsByGameUrl(id),
+          });
+        }),
+      )
+      .subscribe(({ products, pixels }) => {
+        this.initialProductIds = products.map(x => x.productId);
+        this.initialPixelIds = pixels.map(x => x.pixelId);
+
+        this.selectedProductIds.set([...this.initialProductIds]);
+        this.selectedPixelIds.set([...this.initialPixelIds]);
       });
-
-      if (gameUrl.isPublicApi)
-      {
-        this.form.controls.isBatchUrl.disable({ emitEvent: false });
-        this.form.controls.isPixelScrape.disable({ emitEvent: false });
-      }
-
-      this.syncSignalsFromForm();
-
-      this.form.controls.gameId.disable();
-    });
   }
 
-  onSubmit(): void
-  {
-    if (this.form.invalid)
-    {
+  onSubmit(): void {
+    if (this.form.invalid) {
       return;
     }
 
-    if (this.isEditMode && this.gameUrlId)
-    {
+    if (this.isEditMode && this.gameUrlId) {
       const update: UpdateGameUrl = this.form.getRawValue();
 
-      this.gameUrlService.update(this.gameUrlId, update).subscribe(() =>
-      {
-        this.router.navigate(['/game-urls']);
-      });
-    }
-    else
-    {
+      this.gameUrlService
+        .update(this.gameUrlId, update)
+        .pipe(switchMap(() => this.syncRelations(this.gameUrlId!)))
+        .subscribe(() => {
+          this.router.navigate(['/game-urls']);
+        });
+    } else {
       const create: CreateGameUrl = this.form.getRawValue();
 
-      this.gameUrlService.create(create).subscribe(() =>
-      {
-        this.router.navigate(['/game-urls']);
-      });
+      this.gameUrlService
+        .create(create)
+        .pipe(switchMap(created => this.syncRelations(created.id)))
+        .subscribe(() => {
+          this.router.navigate(['/game-urls']);
+        });
     }
   }
 
-  cancel(): void
-  {
+  private syncRelations(gameUrlId: number) {
+    const selectedProducts = this.selectedProductIds();
+    const selectedPixels = this.selectedPixelIds();
+
+    const productAdds = selectedProducts
+      .filter(x => !this.initialProductIds.includes(x))
+      .map(productId => this.gameUrlProductService.create({ productId, gameUrlId }));
+
+    const productDeletes = this.initialProductIds
+      .filter(x => !selectedProducts.includes(x))
+      .map(productId => this.gameUrlProductService.delete(productId, gameUrlId));
+
+    const pixelAdds = selectedPixels
+      .filter(x => !this.initialPixelIds.includes(x))
+      .map(pixelId => this.gameUrlPixelService.create({ pixelId, gameUrlId }));
+
+    const pixelDeletes = this.initialPixelIds
+      .filter(x => !selectedPixels.includes(x))
+      .map(pixelId => this.gameUrlPixelService.delete(pixelId, gameUrlId));
+
+    const requests = [...productAdds, ...productDeletes, ...pixelAdds, ...pixelDeletes];
+
+    if (requests.length === 0) {
+      return of(void 0);
+    }
+
+    return forkJoin(requests).pipe(switchMap(() => of(void 0)));
+  }
+
+  cancel(): void {
     this.router.navigate(['/game-urls']);
   }
 }

--- a/SteamApp.Client/src/app/pages/game-url/game-urls-view/game-urls-view.html
+++ b/SteamApp.Client/src/app/pages/game-url/game-urls-view/game-urls-view.html
@@ -2,27 +2,31 @@
   <div class="flex items-center justify-between mb-4">
     <h2 class="text-2xl font-semibold text-gray-500">Game URLs</h2>
 
-    <button class="create-button" (click)="createButtonClicked()">
-      Create
-    </button>
+    <div class="flex gap-x-2">
+      <button
+        (click)="exportButtonClicked()"
+        class="button button-small-primary"
+        title="Export current data to Excel">
+        Export
+      </button>
+
+      <button class="create-button" (click)="createButtonClicked()">Create</button>
+    </div>
   </div>
 
-  <div class="flex gap-x-5 items-end">
-    <!-- Game (native select) -->
-    <div class="flex flex-col">
-      <label class="mb-1 font-semibold">Game</label>
-      <select class="px-2 py-1"
-              [formControl]="gameIdControl">
+  <div class="filter-toolbar">
+    <div class="filter-group">
+      <label>Game</label>
+      <select class="px-2 py-1" [formControl]="gameIdControl">
         <option [ngValue]="null">All</option>
-        @for (g of games$ | async; track g.id) {
+        @for (g of games(); track g.id) {
           <option [ngValue]="g.id">{{ g.name }}</option>
         }
       </select>
     </div>
 
-    <!-- Name (native input) -->
-    <div class="flex flex-col">
-      <label class="mb-1 font-semibold">Name</label>
+    <div class="filter-group">
+      <label>Name</label>
       <input
         class="px-2 py-1"
         type="text"
@@ -31,9 +35,7 @@
         (input)="onNameFilterChanged($any($event.target).value)">
     </div>
 
-    <button (click)="clearFiltersButtonClicked()" class="button button-small-danger">
-      Clear
-    </button>
+    <button (click)="clearFiltersButtonClicked()" class="button button-small-danger">Clear</button>
   </div>
 
   <div class="table-container">

--- a/SteamApp.Client/src/app/pages/game-url/game-urls-view/game-urls-view.scss
+++ b/SteamApp.Client/src/app/pages/game-url/game-urls-view/game-urls-view.scss
@@ -1,0 +1,24 @@
+.filter-toolbar {
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  label {
+    font-weight: 600;
+  }
+
+  input,
+  select {
+    min-width: 14rem;
+    border: 1px solid #9ca3af;
+    border-radius: 0.375rem;
+  }
+}

--- a/SteamApp.Client/src/app/pages/product/product-form/product-form.html
+++ b/SteamApp.Client/src/app/pages/product/product-form/product-form.html
@@ -2,30 +2,61 @@
   <h2>{{ isEditMode ? 'Edit Product' : 'Create Product' }}</h2>
 
   <div class="form-group">
-  <label>Game *</label>
-  <select formControlName="gameId" class="px-2 py-1">
-    <option value="" disabled>Select a game</option>
-    <option *ngFor="let game of games" [value]="game.id">
-      {{ game.name }}
-    </option>
-  </select>
-</div>
+    <label>Game *</label>
+    <select formControlName="gameId" class="px-2 py-1">
+      <option ngValue="" disabled>Select a game</option>
+      @for (game of games(); track game.id) {
+        <option [ngValue]="game.id">{{ game.name }}</option>
+      }
+    </select>
+  </div>
 
   <div class="form-group">
     <label>Name *</label>
     <input formControlName="name" class="px-2 py-1 w-1/2" placeholder="Product name" />
   </div>
 
-    <div class="form-group">
+  <div class="form-group">
     <label>Rating</label>
     <input type="number" formControlName="rating" class="px-2 py-1 w-1/2" placeholder="Rating" />
   </div>
 
-    <div class="form-group-row checkbox-group">
+  <div class="form-group-row checkbox-group">
     <label>
       <input type="checkbox" formControlName="isActive" />
       Active
     </label>
+  </div>
+
+  <div class="relation-section">
+    <h3>Tags for this Product</h3>
+
+    @if (filteredTags.length === 0) {
+      <p class="relation-empty">No tags available for this game.</p>
+    } @else {
+      <label class="relation-select-all">
+        <input
+          type="checkbox"
+          [checked]="areAllFilteredTagsSelected"
+          [indeterminate]="areSomeFilteredTagsSelected"
+          (change)="toggleAllTags($any($event.target).checked)"
+        />
+        Select all tags
+      </label>
+
+      <div class="relation-grid">
+        @for (tag of filteredTags; track tag.id) {
+          <label>
+            <input
+              type="checkbox"
+              [checked]="isTagSelected(tag.id)"
+              (change)="toggleTag(tag.id, $any($event.target).checked)"
+            />
+            {{ tag.name || 'Unnamed tag' }}
+          </label>
+        }
+      </div>
+    }
   </div>
 
   <div class="flex gap-x-2">
@@ -33,8 +64,6 @@
       {{ isEditMode ? 'Save' : 'Create' }}
     </button>
 
-    <button type="return" (click)="cancel()">
-      Back
-    </button>
+    <button type="button" (click)="cancel()">Back</button>
   </div>
 </form>

--- a/SteamApp.Client/src/app/pages/product/product-form/product-form.scss
+++ b/SteamApp.Client/src/app/pages/product/product-form/product-form.scss
@@ -1,0 +1,25 @@
+.relation-section {
+  margin: 1rem 0;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+}
+
+.relation-select-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+
+.relation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.5rem;
+}
+
+.relation-empty {
+  color: #6b7280;
+  margin: 0;
+}

--- a/SteamApp.Client/src/app/pages/product/product-form/product-form.ts
+++ b/SteamApp.Client/src/app/pages/product/product-form/product-form.ts
@@ -1,11 +1,13 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { forkJoin, of, switchMap } from 'rxjs';
+
 import { GameService, ProductService } from '../../../services';
-import { CreateProduct, Game, UpdateProduct } from '../../../models';
-
-
+import { CreateProduct, Game, Tag, UpdateProduct } from '../../../models';
+import { TagService } from '../../../services/tag/tag.service';
+import { ProductTagService } from '../../../services/product-tag/product-tag.service';
 
 @Component({
   selector: 'steam-product-form',
@@ -18,25 +20,37 @@ export class ProductForm implements OnInit {
   isEditMode = false;
   productId?: number;
 
+  readonly games = signal<readonly Game[]>([]);
+  readonly tags = signal<readonly Tag[]>([]);
+  readonly selectedTagIds = signal<readonly number[]>([]);
+
+  private initialTagIds: number[] = [];
+
   form = this.fb.nonNullable.group({
-    gameId: [0],
+    gameId: [0, Validators.required],
     name: [''],
-    rating: [null],
+    rating: [null as number | null],
     isActive: [true],
   });
 
   constructor(
-    private fb: FormBuilder,
-    private route: ActivatedRoute,
-    private router: Router,
-    private productService: ProductService,
-    private gameService: GameService,
+    private readonly fb: FormBuilder,
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly productService: ProductService,
+    private readonly gameService: GameService,
+    private readonly tagService: TagService,
+    private readonly productTagService: ProductTagService,
   ) {}
 
   ngOnInit(): void {
     const idParam = this.route.snapshot.paramMap.get('id');
 
-    this.loadGames();
+    this.form.controls.gameId.valueChanges.subscribe(() => {
+      this.pruneSelectedTags();
+    });
+
+    this.loadLookupData();
 
     if (idParam) {
       this.isEditMode = true;
@@ -45,33 +59,94 @@ export class ProductForm implements OnInit {
     }
   }
 
-
-  private loadProduct(id: number): void {
-    this.productService.getById(id).subscribe((product) => {
-      this.form.patchValue({
-        gameId: product.gameId,
-        name: product.name ?? '',
-        isActive: product.isActive ?? false,
-      });
-
-      this.form.controls.gameId.disable();
-    });
+  get filteredTags(): readonly Tag[] {
+    const gameId = this.form.controls.gameId.value;
+    return this.tags().filter(x => x.gameId === gameId);
   }
 
-  games: Game[] = [];
-  gameNameById = new Map<number, string>();
+  get areAllFilteredTagsSelected(): boolean {
+    const filtered = this.filteredTags;
+    if (filtered.length === 0) {
+      return false;
+    }
 
-  private loadGames(): void {
-    this.gameService.getAll().subscribe({
-      next: (games) => {
-        this.games = games;
+    const selected = new Set(this.selectedTagIds());
+    return filtered.every(x => selected.has(x.id));
+  }
 
-        this.gameNameById.clear();
-        for (const game of games) {
-          this.gameNameById.set(game.id, game.name);
-        }
-      },
-    });
+  get areSomeFilteredTagsSelected(): boolean {
+    const filtered = this.filteredTags;
+    if (filtered.length === 0) {
+      return false;
+    }
+
+    const selected = new Set(this.selectedTagIds());
+    const selectedCount = filtered.filter(x => selected.has(x.id)).length;
+
+    return selectedCount > 0 && selectedCount < filtered.length;
+  }
+
+  isTagSelected(tagId: number): boolean {
+    return this.selectedTagIds().includes(tagId);
+  }
+
+  toggleTag(tagId: number, checked: boolean): void {
+    const selected = new Set(this.selectedTagIds());
+
+    if (checked) {
+      selected.add(tagId);
+    } else {
+      selected.delete(tagId);
+    }
+
+    this.selectedTagIds.set([...selected]);
+  }
+
+  toggleAllTags(checked: boolean): void {
+    const selected = new Set(this.selectedTagIds());
+
+    for (const tag of this.filteredTags) {
+      if (checked) {
+        selected.add(tag.id);
+      } else {
+        selected.delete(tag.id);
+      }
+    }
+
+    this.selectedTagIds.set([...selected]);
+  }
+
+  private pruneSelectedTags(): void {
+    const allowedTagIds = new Set(this.filteredTags.map(x => x.id));
+    this.selectedTagIds.set(this.selectedTagIds().filter(x => allowedTagIds.has(x)));
+  }
+
+  private loadLookupData(): void {
+    this.gameService.getAll().subscribe(games => this.games.set(games));
+    this.tagService.getAll().subscribe(tags => this.tags.set(tags));
+  }
+
+  private loadProduct(id: number): void {
+    this.productService
+      .getById(id)
+      .pipe(
+        switchMap(product => {
+          this.form.patchValue({
+            gameId: product.gameId,
+            name: product.name ?? '',
+            rating: product.rating ?? null,
+            isActive: product.isActive ?? false,
+          });
+
+          this.form.controls.gameId.disable();
+
+          return this.productTagService.getByProduct(id);
+        }),
+      )
+      .subscribe(productTags => {
+        this.initialTagIds = productTags.map(x => x.tagId);
+        this.selectedTagIds.set([...this.initialTagIds]);
+      });
   }
 
   onSubmit(): void {
@@ -86,16 +161,42 @@ export class ProductForm implements OnInit {
         rating: this.form.controls.rating.value,
       };
 
-      this.productService.update(this.productId, update).subscribe(() => {
-         this.router.navigate(['/products']);
-      });
+      this.productService
+        .update(this.productId, update)
+        .pipe(switchMap(() => this.syncProductTags(this.productId!)))
+        .subscribe(() => {
+          this.router.navigate(['/products']);
+        });
     } else {
       const create: CreateProduct = this.form.getRawValue();
 
-      this.productService.create(create).subscribe(() => {
-         this.router.navigate(['/products']);
-      });
+      this.productService
+        .create(create)
+        .pipe(switchMap(created => this.syncProductTags(created.id)))
+        .subscribe(() => {
+          this.router.navigate(['/products']);
+        });
     }
+  }
+
+  private syncProductTags(productId: number) {
+    const selectedTags = this.selectedTagIds();
+
+    const adds = selectedTags
+      .filter(x => !this.initialTagIds.includes(x))
+      .map(tagId => this.productTagService.create({ productId, tagId }));
+
+    const deletes = this.initialTagIds
+      .filter(x => !selectedTags.includes(x))
+      .map(tagId => this.productTagService.delete(productId, tagId));
+
+    const requests = [...adds, ...deletes];
+
+    if (requests.length === 0) {
+      return of(void 0);
+    }
+
+    return forkJoin(requests).pipe(switchMap(() => of(void 0)));
   }
 
   cancel(): void {

--- a/SteamApp.Client/src/app/pages/product/products-view/products-view.html
+++ b/SteamApp.Client/src/app/pages/product/products-view/products-view.html
@@ -1,105 +1,101 @@
 <div class="p-4">
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-2xl font-semibold text-gray-500">
-      Products
-    </h2>
+    <h2 class="text-2xl font-semibold text-gray-500">Products</h2>
 
-    <button class="create-button" (click)="createButtonClicked()">
-      Create
-    </button>
+    <div class="flex gap-x-2">
+      <button
+        (click)="exportButtonClicked()"
+        class="button button-small-primary"
+        title="Export current data to Excel">
+        Export
+      </button>
+
+      <button class="create-button" (click)="createButtonClicked()">Create</button>
+    </div>
   </div>
-    <div class="flex gap-x-5">
-      
-      <!-- Game -->
-      <app-combo-box label="Game" [control]="gameIdControl" [items$]="games$" idKey="id" labelKey="name" [bind$]="bindToExternal$"></app-combo-box>
-      
-      <!-- Product Name -->
-    <app-text-filter [SearchLabel]="'Product Name'" [SearchTextBind]="searchByNameFilterControl"
-      (filterChange)="onNameFilterChanged($event)">
-    </app-text-filter>
 
-    <!-- Rating -->
-    <app-number-filter [SearchLabel]="'Rating'" [SearchNumberBind]="searchByRatingFilterControl"
-      (filterChange)="onRatingFilterChanged($event)">
-    </app-number-filter>
+  <div class="filter-toolbar">
+    <div class="filter-group">
+      <label>Game</label>
+      <select class="px-2 py-1" [formControl]="gameIdControl">
+        <option [ngValue]="null">All</option>
+        @for (g of games(); track g.id) {
+          <option [ngValue]="g.id">{{ g.name }}</option>
+        }
+      </select>
+    </div>
 
-     <!-- Tags -->
-    <app-tag-filter-select label="Tags" [control]="tagSelectControl" [options]="gameTagsFilter" [filters]="tagsFilter"
-      (tagSelected)="onTagSelectedFromComponent($event)" (removeClicked)="removeFilter($event)"></app-tag-filter-select>
+    <div class="filter-group">
+      <label>Product Name</label>
+      <input class="px-2 py-1" type="text" placeholder="Filter by name" [formControl]="searchByNameFilterControl" />
+    </div>
 
-    <button (click)="clearFiltersButtonClicked()" class="button button-small-danger"> Clear </button>
+    <div class="filter-group">
+      <label>Rating</label>
+      <input class="px-2 py-1" type="number" placeholder="Filter by rating" [formControl]="searchByRatingFilterControl" />
+    </div>
+
+    <div class="filter-group min-w-[220px]">
+      <label>Tags</label>
+      <select class="px-2 py-1" [formControl]="tagIdControl" [disabled]="gameTagsFilter().length === 0" (change)="onTagSelectedFromSelect()">
+        <option [ngValue]="null">Select a tag</option>
+        @for (tag of gameTagsFilter(); track tag.id) {
+          <option [ngValue]="tag.id">{{ tag.name }}</option>
+        }
+      </select>
+    </div>
+
+    <button (click)="clearFiltersButtonClicked()" class="button button-small-danger">Clear</button>
   </div>
+
+  @if (tagsFilter().length > 0) {
+    <div class="tag-chip-row">
+      @for (filter of tagsFilter(); track filter) {
+        <div class="tag-chip">
+          <span>{{ filter }}</span>
+          <button type="button" (click)="removeFilter(filter)">×</button>
+        </div>
+      }
+    </div>
+  }
 
   <div class="table-container">
     <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
-
-      <!-- Game -->
       <ng-container matColumnDef="gameName">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Game</th>
-        <td mat-cell *matCellDef="let row">
-          {{ row.gameName || '—' }}
-        </td>
+        <td mat-cell *matCellDef="let row">{{ row.gameName || '—' }}</td>
       </ng-container>
 
-      <!-- Name -->
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
-        <td mat-cell *matCellDef="let row">
-          {{ row.name || '—' }}
-        </td>
+        <td mat-cell *matCellDef="let row">{{ row.name || '—' }}</td>
       </ng-container>
 
-
-
-      <!-- Tags -->
       <ng-container matColumnDef="tags">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Tags</th>
-        <td mat-cell *matCellDef="let row">
-          {{ row.tags?.join(', ') || '—' }}
-        </td>
+        <td mat-cell *matCellDef="let row">{{ row.tags?.join(', ') || '—' }}</td>
       </ng-container>
 
-            <!-- Rating -->
       <ng-container matColumnDef="rating">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Rating</th>
-        <td mat-cell *matCellDef="let row">
-          {{ row.rating  || '—' }}
-        </td>
+        <td mat-cell *matCellDef="let row">{{ row.rating || '—' }}</td>
       </ng-container>
 
-      <!--  Page -->
-      <!-- <ng-container matColumnDef="fullUrl">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Page URL</th>
-        <td mat-cell *matCellDef="let row">
-          <a [href]="row.fullUrl" [title]="row.fullUrl" target="_blank" rel="noopener noreferrer"><p><b>&lt;-- Link --&gt;</b></p></a>
-        </td>
-      </ng-container> -->
-
-      
-      <!-- Active -->
       <ng-container matColumnDef="isActive">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Active</th>
-        <td mat-cell *matCellDef="let row">
-          <input type="checkbox" [checked]="row.isActive" disabled />
-        </td>
+        <td mat-cell *matCellDef="let row"><input type="checkbox" [checked]="row.isActive" disabled /></td>
       </ng-container>
 
-      <!-- Actions -->
       <ng-container matColumnDef="actions">
         <th mat-header-cell *matHeaderCellDef>Actions</th>
         <td mat-cell *matCellDef="let row" class="flex justify-center gap-x-2 py-2">
-
           <button class="{{row.isActive === true ? 'delete-button'  : 'edit-button'}}" (click)="activeButtonClicked(row)">
-           {{row.isActive === true ? 'Deactivate'  : 'Activate'}}
+            {{row.isActive === true ? 'Deactivate'  : 'Activate'}}
           </button>
 
-          <button class="edit-button" (click)="editButtonClicked(row.id)" (auxclick)="openInNewTab(row.id)">
-            Edit
-          </button>
+          <button class="edit-button" (click)="editButtonClicked(row.id)" (auxclick)="openInNewTab(row.id)">Edit</button>
 
-          <button class="delete-button" (click)="deleteButtonClicked(row.id)">
-            Delete
-          </button>
+          <button class="delete-button" (click)="deleteButtonClicked(row.id)">Delete</button>
         </td>
       </ng-container>
 

--- a/SteamApp.Client/src/app/pages/product/products-view/products-view.scss
+++ b/SteamApp.Client/src/app/pages/product/products-view/products-view.scss
@@ -1,0 +1,40 @@
+.filter-toolbar {
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  label {
+    font-weight: 600;
+  }
+
+  input,
+  select {
+    min-width: 14rem;
+    border: 1px solid #9ca3af;
+    border-radius: 0.375rem;
+  }
+}
+
+.tag-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #9ca3af;
+  border-radius: 0.375rem;
+}

--- a/SteamApp.Client/src/app/pages/product/products-view/products-view.ts
+++ b/SteamApp.Client/src/app/pages/product/products-view/products-view.ts
@@ -1,46 +1,27 @@
-import { ChangeDetectorRef, Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
-import {
-  GameService,
-  ProductService,
-  TagService,
-} from '../../../services';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Subject, takeUntil } from 'rxjs';
+
+import { GameService, ProductService, TagService } from '../../../services';
 import { Game, Product, Tag, UpdateProductStatus } from '../../../models';
-import { encode } from '../../../common';
-import { FormControl } from '@angular/forms';
-import { TextFilterComponent } from '../../../components';
-import { NumberFilterComponent } from '../../../components/filter-components/number-filter.component';
-import { TagFilterSelectComponent } from '../../../components/filter-components/tag-filter.component';
-import { BehaviorSubject, startWith, Subject, takeUntil, tap } from 'rxjs';
-import { ComboBoxComponent } from '../../../components/filter-components/combo-box-filter.component';
+import * as XLSX from 'xlsx';
 
 @Component({
   selector: 'steam-products-grid',
   standalone: true,
-  imports: [
-    CommonModule,
-    MatTableModule,
-    MatPaginatorModule,
-    MatSortModule,
-    TextFilterComponent,
-    NumberFilterComponent,
-    TagFilterSelectComponent,
-    ComboBoxComponent,
-  ],
+  imports: [CommonModule, ReactiveFormsModule, MatTableModule, MatPaginatorModule, MatSortModule],
   templateUrl: './products-view.html',
   styleUrl: './products-view.scss',
 })
-export class ProductsView implements OnInit {
+export class ProductsView implements OnInit, OnDestroy {
   displayedColumns: string[] = [
-    //'id',
-    //'gameId',
     'gameName',
-    //'fullUrl',
     'name',
     'tags',
     'rating',
@@ -51,54 +32,57 @@ export class ProductsView implements OnInit {
   private readonly destroy$ = new Subject<void>();
 
   readonly gameIdControl = new FormControl<number | null>(null);
-  private games: Game[] = [];
-  readonly games$ = new BehaviorSubject<readonly Game[]>([]);
+  readonly searchByNameFilterControl = new FormControl<string>('', { nonNullable: true });
+  readonly searchByRatingFilterControl = new FormControl<number | null>(null, { nonNullable: true });
+  readonly tagIdControl = new FormControl<number | null>(null);
+
+  readonly games = signal<readonly Game[]>([]);
+  readonly products = signal<readonly Product[]>([]);
+  readonly gameTagsAll = signal<readonly Tag[]>([]);
+  readonly gameTagsFilter = signal<readonly Tag[]>([]);
+  readonly tagsFilter = signal<readonly string[]>([]);
 
   dataSource = new MatTableDataSource<Product>([]);
-
-  products: Product[] = [];
-  productsFiltered: Product[] = [];
-
-  private gameTagsAll: Tag[] = [];
-  gameTagsFilter: Tag[] = [];
-  tagsFilter: string[] = [];
-
-  readonly tagSelectControl = new FormControl<Tag | null>({
-    value: null,
-    disabled: true,
-  });
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
 
   constructor(
-    private productService: ProductService,
-    private gameService: GameService,
-    private tagsService: TagService,
-    private router: Router,
-    private readonly cdr: ChangeDetectorRef,
+    private readonly productService: ProductService,
+    private readonly gameService: GameService,
+    private readonly tagsService: TagService,
+    private readonly router: Router,
   ) {}
 
   ngOnInit(): void {
     this.loadGames();
     this.loadGameTags();
-
     this.fetchProducts();
+
+    this.gameIdControl.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(gameId => this.applyGameFilter(gameId));
+
+    this.searchByNameFilterControl.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.loadFilteredProducts());
+
+    this.searchByRatingFilterControl.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.loadFilteredProducts());
   }
 
-  readonly bindToExternal$ = this.gameIdControl.valueChanges.pipe(
-    startWith(this.gameIdControl.value),
-    tap((gameId) => {
-      this.applyGameFilter(gameId);
-    }),
-  );
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 
   private loadGameTags(): void {
     this.tagsService
       .getAll()
       .pipe(takeUntil(this.destroy$))
-      .subscribe((tags) => {
-        this.gameTagsAll = tags;
+      .subscribe(tags => {
+        this.gameTagsAll.set(tags);
         this.applyGameFilter(this.gameIdControl.value);
       });
   }
@@ -107,57 +91,54 @@ export class ProductsView implements OnInit {
     this.gameService
       .getAll()
       .pipe(takeUntil(this.destroy$))
-      .subscribe((games) => {
-        this.games = games;
-        this.games$.next(games);
-        this.cdr.markForCheck();
+      .subscribe(games => {
+        this.games.set(games);
       });
   }
 
   private applyGameFilter(gameId: number | null): void {
-    this.tagsFilter = [];
-    this.tagSelectControl.setValue(null);
+    this.tagsFilter.set([]);
+    this.tagIdControl.setValue(null, { emitEvent: false });
 
     if (gameId === null) {
-      this.gameTagsFilter = [];
-      this.tagSelectControl.disable();
-
-      this.cdr.markForCheck();
+      this.gameTagsFilter.set([]);
+      this.loadFilteredProducts();
       return;
     }
 
-    this.gameTagsFilter = this.gameTagsAll.filter(
-      (tag) => tag.gameId === gameId,
-    );
-    if (this.gameTagsFilter.length) {
-      this.tagSelectControl.enable();
-    } else {
-      this.tagSelectControl.disable();
-    }
-
-    this.productsFiltered = this.products.filter(x => x.gameId === gameId);
-    this.dataSource.data = this.productsFiltered ;
-
-    this.cdr.markForCheck();
+    this.gameTagsFilter.set(this.gameTagsAll().filter(tag => tag.gameId === gameId));
+    this.loadFilteredProducts();
   }
 
   fetchProducts(): void {
-    this.productService.getAll().subscribe((products) => {
+    this.productService.getAll().subscribe(products => {
+      this.products.set(products);
       this.dataSource.data = products;
       this.dataSource.paginator = this.paginator;
       this.dataSource.sort = this.sort;
-
-      this.products = products;
-      this.productsFiltered = products;
     });
+  }
+
+
+  exportButtonClicked(): void {
+    const dataToExport = this.dataSource.data.map(x => ({
+      gameName: x.gameName,
+      name: x.name ?? '',
+      tags: x.tags?.join(', ') ?? '',
+      rating: x.rating ?? '',
+      isActive: x.isActive,
+    }));
+
+    const worksheet: XLSX.WorkSheet = XLSX.utils.json_to_sheet(dataToExport);
+    const workbook: XLSX.WorkBook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Products');
+
+    const today = new Date();
+    XLSX.writeFile(workbook, `Export_${today.toDateString()}_Products.xlsx`);
   }
 
   createButtonClicked(): void {
     this.router.navigate(['/products/create']);
-  }
-
-  encodeText(value: string): string {
-    return encode(value);
   }
 
   editButtonClicked(id: number): void {
@@ -176,17 +157,11 @@ export class ProductsView implements OnInit {
       .updateStatus(input)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
-        this.products = this.products.map((p) =>
-          p.id === product.id ? { ...p, isActive: nextIsActive } : p,
+        this.products.set(
+          this.products().map(p => (p.id === product.id ? { ...p, isActive: nextIsActive } : p)),
         );
 
-        this.productsFiltered = this.productsFiltered.map((p) =>
-          p.id === product.id ? { ...p, isActive: nextIsActive } : p,
-        );
-
-        this.dataSource.data = this.productsFiltered;
-
-        this.cdr.markForCheck();
+        this.loadFilteredProducts();
       });
   }
 
@@ -197,110 +172,79 @@ export class ProductsView implements OnInit {
 
     this.productService.delete(id).subscribe(() => {
       this.fetchProducts();
+      this.loadFilteredProducts();
     });
   }
 
-  searchByNameFilterControl = new FormControl<string>('', {
-    nonNullable: true,
-  });
+  onTagSelectedFromSelect(): void {
+    const selectedTagId = this.tagIdControl.value;
+    if (selectedTagId === null) {
+      return;
+    }
 
-  searchByRatingFilterControl = new FormControl<number | null>(null, {
-    nonNullable: true,
-  });
-
-  onTagSelectedFromComponent(tag: Tag): void {
-    if (!tag.name) {
+    const tag = this.gameTagsFilter().find(x => x.id === selectedTagId);
+    if (!tag?.name) {
       return;
     }
 
     const tagName = tag.name.toLowerCase();
-    if (!this.tagsFilter.includes(tagName)) {
-      this.tagsFilter.push(tagName);
+    const filters = this.tagsFilter();
+
+    if (!filters.includes(tagName)) {
+      this.tagsFilter.set([...filters, tagName]);
     }
 
-    this.gameTagsFilter = this.gameTagsFilter.filter((t) => t.id !== tag.id);
-    if (this.gameTagsFilter.length) {
-      this.tagSelectControl.enable();
-    } else {
-      this.tagSelectControl.disable();
-    }
+    this.gameTagsFilter.set(this.gameTagsFilter().filter(t => t.id !== tag.id));
+    this.tagIdControl.setValue(null, { emitEvent: false });
 
-    this.loadFilteredProducts();
-  }
-
-  onNameFilterChanged(filter: string): void {
-    this.searchByNameFilterControl.setValue(filter, { emitEvent: false });
-    this.loadFilteredProducts();
-  }
-
-  onRatingFilterChanged(filter: number): void {
-    this.searchByRatingFilterControl.setValue(filter, { emitEvent: false });
     this.loadFilteredProducts();
   }
 
   private loadFilteredProducts(): void {
-    const nameFilter =
-      this.searchByNameFilterControl.value?.toLowerCase() ?? '';
-
+    const gameId = this.gameIdControl.value;
+    const nameFilter = this.searchByNameFilterControl.value?.toLowerCase() ?? '';
     const ratingFilter = this.searchByRatingFilterControl.value;
-    const tagFilters = this.tagsFilter.map((t) => t.toLowerCase());
+    const tagFilters = this.tagsFilter().map(t => t.toLowerCase());
 
-    this.productsFiltered = this.products.filter((product) => {
-      const matchesName =
-        (!nameFilter || product.name?.toLowerCase().includes(nameFilter)) &&
-        (!ratingFilter || product.rating == ratingFilter);
-
+    const filtered = this.products().filter(product => {
+      const matchesGame = gameId === null || product.gameId === gameId;
+      const matchesName = !nameFilter || product.name?.toLowerCase().includes(nameFilter);
+      const matchesRating = !ratingFilter || product.rating == ratingFilter;
       const matchesTags =
         tagFilters.length === 0 ||
-        tagFilters.every((filter) =>
-          product.tags?.some((tag) => tag.toLowerCase().includes(filter)),
-        );
+        tagFilters.every(filter => product.tags?.some(tag => tag.toLowerCase().includes(filter)));
 
-      return matchesName && matchesTags;
+      return matchesGame && matchesName && matchesRating && matchesTags;
     });
 
-    this.dataSource.data = this.productsFiltered;
+    this.dataSource.data = filtered;
   }
 
   clearFiltersButtonClicked(): void {
     this.searchByNameFilterControl.setValue('', { emitEvent: false });
     this.searchByRatingFilterControl.setValue(null, { emitEvent: false });
+    this.gameIdControl.setValue(null, { emitEvent: false });
 
-    this.gameIdControl.setValue(null);
-
-    this.searchByNameFilterControl.setValue('', { emitEvent: false });
-    this.tagsFilter = [];
-
-    const gameId = this.gameIdControl.value;
-    this.gameTagsFilter =
-      gameId === null
-        ? []
-        : this.gameTagsAll.filter((t) => t.gameId === gameId);
-
-    this.tagSelectControl.setValue(null);
-    if (this.gameTagsFilter.length) {
-      this.tagSelectControl.enable();
-    } else {
-      this.tagSelectControl.disable();
-    }
+    this.tagsFilter.set([]);
+    this.tagIdControl.setValue(null, { emitEvent: false });
+    this.gameTagsFilter.set([]);
 
     this.loadFilteredProducts();
   }
 
   removeFilter(value: string): void {
-    this.tagsFilter = this.tagsFilter.filter((f) => f !== value);
+    this.tagsFilter.set(this.tagsFilter().filter(f => f !== value));
 
-    const restored = this.gameTagsAll.find(
-      (t) =>
+    const restored = this.gameTagsAll().find(
+      t =>
         t.gameId === this.gameIdControl.value &&
         t.name !== null &&
         t.name.toLowerCase() === value,
     );
 
-    if (restored && !this.gameTagsFilter.some((t) => t.id === restored.id)) {
-      this.gameTagsFilter.push(restored);
-      this.gameTagsFilter.sort((a, b) =>
-        (a.name ?? '').localeCompare(b.name ?? ''),
+    if (restored && !this.gameTagsFilter().some(t => t.id === restored.id)) {
+      this.gameTagsFilter.set(
+        [...this.gameTagsFilter(), restored].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
       );
     }
 

--- a/SteamApp.Client/src/app/services/game-url-pixel/game-url-pixel.service.ts
+++ b/SteamApp.Client/src/app/services/game-url-pixel/game-url-pixel.service.ts
@@ -30,6 +30,14 @@ export class GameUrlPixelService {
       .pipe(catchError(handleError));
   }
 
+
+  // GET: /api/game-url-pixels/{gameUrlId}
+  existsByGameUrl(gameUrlId: number): Observable<GameUrlPixel[]> {
+    return this.http
+      .get<GameUrlPixel[]>(`${this.baseUrl}/${gameUrlId}`)
+      .pipe(catchError(handleError));
+  }
+
   // POST: /api/game-url-pixels
   create(input: CreateGameUrlPixel): Observable<void> {
     return this.http

--- a/SteamApp.Server/SteamApp.WebAPI/MinimalAPIs/GameUrlPixelsEndpoints.cs
+++ b/SteamApp.Server/SteamApp.WebAPI/MinimalAPIs/GameUrlPixelsEndpoints.cs
@@ -55,6 +55,34 @@ public static class GameUrlPixelsEndpoints
                 : Results.NotFound();
         });
 
+        // GET: /api/game-url-pixels/{gameUrlId}
+        group.MapGet("/{gameUrlId:long}", async (
+            long gameUrlId,
+            ApplicationDbContext db) =>
+        {
+            var relations = await db.GameUrlsPixels
+                .AsNoTracking()
+                .Where(x => x.GameUrlId == gameUrlId)
+                .Select(x => new
+                {
+                    x.PixelId,
+                    PixelName = x.Pixel.Name,
+                    x.GameUrlId,
+                    GameUrlName = x.GameUrl.Name,
+                    GameName = x.GameUrl.Game.Name,
+                    GameUrlPixelLocationX = x.GameUrl.PixelX,
+                    GameUrlPixelLocationY = x.GameUrl.PixelY,
+                    GameUrlImageWidth = x.GameUrl.PixelImageWidth,
+                    GameUrlImageHeight = x.GameUrl.PixelImageHeight,
+                    x.Pixel.RedValue,
+                    x.Pixel.BlueValue,
+                    x.Pixel.GreenValue
+                })
+                .ToListAsync();
+
+            return Results.Ok(relations);
+        });
+
         // POST: /api/game-url-pixels
         group.MapPost("/", async (
             GameUrlPixelCreateDto input,

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,122 @@
+# API Reference (Quick)
+
+Auth: Bearer JWT (global for protected groups).
+
+> Tip: use backend Swagger UI for live schemas/examples.
+
+## Auth
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/api/Auth/token` | Get access token |
+
+## Games
+
+| Method | Path |
+|---|---|
+| GET | `/api/games` |
+| POST | `/api/games` |
+| GET | `/api/games/{id}` |
+| PUT | `/api/games/{id}` |
+| DELETE | `/api/games/{id}` |
+
+## Game URLs
+
+| Method | Path |
+|---|---|
+| GET | `/api/game-urls` |
+| POST | `/api/game-urls` |
+| GET | `/api/game-urls/{id}` |
+| PUT | `/api/game-urls/{id}` |
+| DELETE | `/api/game-urls/{id}` |
+
+## Products
+
+| Method | Path |
+|---|---|
+| GET | `/api/products` |
+| POST | `/api/products` |
+| GET | `/api/products/{id}` |
+| PUT | `/api/products/{id}` |
+| DELETE | `/api/products/{id}` |
+
+## Pixels
+
+| Method | Path |
+|---|---|
+| GET | `/api/pixels` |
+| POST | `/api/pixels` |
+| GET | `/api/pixels/{id}` |
+| PUT | `/api/pixels/{id}` |
+| DELETE | `/api/pixels/{id}` |
+
+## Tags
+
+| Method | Path |
+|---|---|
+| GET | `/api/tags` |
+| POST | `/api/tags` |
+| GET | `/api/tags/{id}` |
+| PUT | `/api/tags/{id}` |
+| DELETE | `/api/tags/{id}` |
+| GET | `/api/tags/game/{gameId}` |
+
+## Product Tags (M2M)
+
+| Method | Path |
+|---|---|
+| GET | `/api/product-tags` |
+| POST | `/api/product-tags` |
+| GET | `/api/product-tags/{productId}/{tagId}` |
+| DELETE | `/api/product-tags/{productId}/{tagId}` |
+| GET | `/api/product-tags/product/{productId}` |
+
+## Game URL Products (M2M)
+
+| Method | Path |
+|---|---|
+| GET | `/api/game-url-products` |
+| POST | `/api/game-url-products` |
+| GET | `/api/game-url-products/{productId}/{gameUrlId}` |
+| DELETE | `/api/game-url-products/{productId}/{gameUrlId}` |
+| GET | `/api/game-url-products/{gameUrlId}` |
+
+## Game URL Pixels (M2M)
+
+| Method | Path |
+|---|---|
+| GET | `/api/game-url-pixels` |
+| POST | `/api/game-url-pixels` |
+| GET | `/api/game-url-pixels/{pixelId}/{gameUrlId}` |
+| DELETE | `/api/game-url-pixels/{pixelId}/{gameUrlId}` |
+| GET | `/api/game-url-pixels/{gameUrlId}` |
+
+## Watch List
+
+| Method | Path |
+|---|---|
+| GET | `/api/watch-list` |
+| POST | `/api/watch-list` |
+| GET | `/api/watch-list/{id}` |
+| PUT | `/api/watch-list/{id}` |
+| DELETE | `/api/watch-list/{id}` |
+
+## Wish List
+
+| Method | Path |
+|---|---|
+| GET | `/api/wish-list` |
+| POST | `/api/wish-list` |
+| GET | `/api/wish-list/{id}` |
+| PUT | `/api/wish-list/{id}` |
+| DELETE | `/api/wish-list/{id}` |
+
+## Steam scraping endpoints
+
+| Method | Path |
+|---|---|
+| GET | `/steam/scrape-page/gameUrl/{gamerUrlId}/page/{page}` |
+| GET | `/steam/scrape-public-api/gameUrl/{gameUrlId}/page/{page}` |
+| GET | `/steam/pixel-info/gameUrl/{gameUrlId}` |
+| GET | `/steam/scrape-pixels/gameUrl/{gamerUrlId}/page/{page}` |
+| GET | `/steam/check-wishlist/{wishlistId}` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,114 @@
+# Architecture Overview
+
+## High-level system
+
+```text
+Angular Client (SteamApp.Client)
+        |
+        | HTTPS + Bearer JWT
+        v
+ASP.NET Core API (SteamApp.WebAPI)
+        |
+        | EF Core
+        v
+SQL Server
+```
+
+Additionally, the backend integrates with Steam endpoints for scraping workflows and runs background jobs for periodic tasks.
+
+---
+
+## Backend layers
+
+Located under `SteamApp.Server/`:
+
+- **SteamApp.WebAPI**
+  - Application host
+  - Dependency injection, auth, CORS, swagger
+  - Minimal API endpoint registration + controllers
+- **SteamApp.Application**
+  - DTOs
+  - operation result models
+  - shared application contracts
+- **SteamApp.Infrastructure**
+  - repository/services implementations
+- **SteamApp.Models**
+  - domain entities/value objects
+- **SteamApp.WebApiClient**
+  - internal API client wrappers
+- **SteamApp.Tests**
+  - test project(s)
+
+---
+
+## Frontend organization
+
+Located under `SteamApp.Client/src/app/`:
+
+- `pages/` — route-level views/forms (CRUD and scraping screens)
+- `services/` — HTTP clients for each API resource
+- `models/` — typed client-side models
+- `components/` — reusable UI components
+
+The app uses route guards and interceptors for auth-protected navigation/API calls.
+
+---
+
+## Key domain entities
+
+- Game
+- GameUrl
+- Product
+- Pixel
+- Tag
+- WishList
+- WatchList
+
+### Important many-to-many relationships
+
+- GameUrl ↔ Product
+- GameUrl ↔ Pixel
+- Product ↔ Tag
+
+These are managed from primary entity forms in the current UX.
+
+---
+
+## API composition
+
+The API exposes:
+
+- **Auth** endpoint for token issuing
+- **CRUD** endpoints for core entities
+- **M2M relation endpoints** for relation tables
+- **Steam scraping endpoints** for listing/pixel workflows
+
+Swagger/OpenAPI is enabled by default in the WebAPI host.
+
+---
+
+## Security model
+
+- JWT bearer authentication
+- Authorization required on grouped endpoints
+- Dedicated `InternalJob` policy for internal scope claims
+
+---
+
+## Background processing
+
+The backend registers a hosted worker for wishlist checks.
+Worker options are controlled through configuration (`Workers:WishlistCheck`).
+
+---
+
+## Configuration model
+
+Config is loaded from:
+
+1. `appsettings.json`
+2. `appsettings.{Environment}.json`
+3. environment variables
+4. user secrets (development)
+
+Startup fails fast if required settings are missing.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+Thanks for your interest in contributing.
+
+## Branching and PRs
+
+- Create a feature branch from your main development branch.
+- Keep commits small and focused.
+- Open a PR with:
+  - What changed
+  - Why it changed
+  - How it was tested
+  - Screenshots for UI changes
+
+## Local checks
+
+### Frontend
+
+```bash
+cd SteamApp.Client
+npm install
+npm run build -- --configuration development
+npm test
+```
+
+### Backend
+
+```bash
+cd SteamApp.Server/SteamApp.WebAPI
+dotnet restore
+dotnet build
+dotnet test
+```
+
+## Coding guidelines
+
+- Prefer readable, explicit naming over clever shorthand.
+- Keep component/service responsibilities focused.
+- For API changes:
+  - update DTOs/contracts
+  - update client services
+  - update docs (`docs/API_REFERENCE.md`)
+- For UI changes:
+  - keep behavior consistent with existing UX patterns
+  - include screenshot evidence in PR
+
+## Commit message examples
+
+- `feat(products): add export action to products table`
+- `fix(game-url-form): preserve selected relations when editing`
+- `docs: expand getting-started and architecture guides`
+
+## Reporting issues
+
+Please include:
+
+- exact steps to reproduce
+- expected vs actual behavior
+- logs/error messages
+- runtime versions (`node -v`, `dotnet --version`)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,144 @@
+# Getting Started
+
+This guide covers local setup for both backend and frontend.
+
+## Prerequisites
+
+- **Node.js** latest LTS (recommended)
+- **npm** (bundled with Node)
+- **.NET 9 SDK**
+- **SQL Server** instance (local or remote)
+- Optional: EF Core tools (`dotnet-ef`) if you apply migrations manually
+
+---
+
+## 1. Clone repository
+
+```bash
+git clone <your-repository-url>
+cd Steam-Web-Scraping-CRM
+```
+
+---
+
+## 2. Configure backend secrets/config
+
+The API validates required configuration keys at startup.
+
+Required keys:
+
+- `ConnectionStrings:DefaultConnection`
+- `JwtSettings:Key`
+- `JwtSettings:Issuer`
+- `JwtSettings:Audience`
+- `InternalClient:ClientSecret`
+
+You can set these using **User Secrets** (recommended in development) and/or environment variables.
+
+### Option A — User Secrets (recommended)
+
+```bash
+cd SteamApp.Server/SteamApp.WebAPI
+# initialize once if needed
+dotnet user-secrets init
+
+# examples
+dotnet user-secrets set "ConnectionStrings:DefaultConnection" "Server=.;Database=SteamAppDb;Trusted_Connection=True;TrustServerCertificate=True;"
+dotnet user-secrets set "JwtSettings:Key" "<very-long-random-key>"
+dotnet user-secrets set "JwtSettings:Issuer" "SteamApp"
+dotnet user-secrets set "JwtSettings:Audience" "SteamAppClient"
+dotnet user-secrets set "InternalClient:ClientSecret" "<secret>"
+```
+
+### Option B — Environment variables
+
+Set equivalent variables using `__` as section separator, for example:
+
+- `ConnectionStrings__DefaultConnection`
+- `JwtSettings__Key`
+
+---
+
+## 3. Backend startup
+
+```bash
+cd SteamApp.Server/SteamApp.WebAPI
+dotnet restore
+dotnet build
+dotnet run
+```
+
+Swagger should be available at `/swagger` on the backend URL.
+
+---
+
+## 4. Database migrations (if needed)
+
+If your environment needs migrations applied manually:
+
+```bash
+cd SteamApp.Server/SteamApp.WebAPI
+dotnet ef database update
+```
+
+> If EF tools are not installed: `dotnet tool install --global dotnet-ef`
+
+---
+
+## 5. Frontend startup
+
+```bash
+cd SteamApp.Client
+npm install
+npm start
+```
+
+The Angular app runs on `http://localhost:4200` by default.
+
+---
+
+## 6. Authentication flow
+
+Most API endpoints require JWT auth. Typical flow:
+
+1. Call `POST /api/Auth/token`
+2. Use returned bearer token in `Authorization: Bearer <token>`
+3. Access protected endpoints
+
+---
+
+## 7. Common troubleshooting
+
+### API throws “Missing required configuration”
+
+One of required keys is missing or empty. Re-check secrets/env vars.
+
+### Angular production build fails due Google Fonts inlining
+
+If environment/network blocks fonts.googleapis.com, production build can fail with 403 during font inlining. Use development build (`ng build --configuration development`) for local verification in restricted environments.
+
+### CORS/auth issues
+
+- Confirm backend is running
+- Confirm frontend points to correct API base URL
+- Ensure bearer token is set and not expired
+
+---
+
+## 8. Useful commands
+
+### Frontend
+
+```bash
+npm start
+npm run build -- --configuration development
+npm test
+```
+
+### Backend
+
+```bash
+dotnet restore
+dotnet build
+dotnet test
+```


### PR DESCRIPTION
### Motivation

- Provide first-class management of many-to-many relations (GameUrl↔Product, GameUrl↔Pixel, Product↔Tag) from primary entity forms to simplify editing and preserve relations during create/update flows.
- Improve list views with filtering and an export-to-Excel action to make offline review and reporting easier.
- Surface a backend endpoint to return existing GameUrl↔Pixel relations by GameUrl and add documentation to help onboard contributors.

### Description

- Reworked `README.md` into a concise top-level project summary and added a small `docs/` set (`GETTING_STARTED.md`, `ARCHITECTURE.md`, `API_REFERENCE.md`, `CONTRIBUTING.md`).
- GameUrl form (`game-url-form.*`) now shows selectable lists of related Products and Pixels, preserves initial relations when editing, and synchronizes additions/deletes via new client calls to `GameUrlProductService` and `GameUrlPixelService` during create/update flows; added corresponding styles and signal-based state management in the component TypeScript.
- Product form (`product-form.*`) now supports selecting Tags for a Product with select-all / per-item toggles, preserves initial tag relations on edit, and synchronizes changes via `ProductTagService`; introduced signal-based state and styles.
- Updated list views for Game URLs and Products to add filter toolbars and an `Export` button that writes the current table to an XLSX file via `xlsx` (`XLSX.writeFile`), and refactored reactive state handling using Angular signals and reactive form controls.
- Simplified header navigation to use direct links for primary pages and removed a few nested dropdowns for Game URL / Product relation pages.
- Client service change: `GameUrlPixelService` exposes `existsByGameUrl(gameUrlId)` to fetch relation details by GameUrl.
- Backend change: `GameUrlPixelsEndpoints` adds a GET `/api/game-url-pixels/{gameUrlId}` endpoint returning relation entries for a given GameUrl.

### Testing

- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44b85b02c832fb0bdf3efd5c5308e)